### PR TITLE
M1: GHA CI + scheduler unit tests (#9, #7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node: ["20", "22"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test (build + unit tests)
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "uninstall-launchd": "node dist/src/ai-limit-timer.js uninstall-launchd",
     "install-systemd": "node dist/src/ai-limit-timer.js install-systemd",
     "uninstall-systemd": "node dist/src/ai-limit-timer.js uninstall-systemd",
-    "test": "npm run build && node --test dist/test/parsers.test.js"
+    "test:unit": "node --test dist/test/parsers.test.js dist/test/scheduler.test.js",
+    "test": "npm run build && npm run test:unit"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatOnCalendarLocal } from "../src/scheduler/systemd.js";
+
+test("formatOnCalendarLocal matches systemd OnCalendar local-time shape", () => {
+  const s = formatOnCalendarLocal(1_700_000_000_000);
+  assert.match(
+    s,
+    /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{1,4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}$/,
+    "expected: '<Weekday> YYYY-M-D H:M:S' (unpadded month/day/hour as systemd allows)",
+  );
+});
+
+test("formatOnCalendarLocal is stable for a fixed offset (structure only)", () => {
+  const a = formatOnCalendarLocal(1_000_000_000_000);
+  const b = formatOnCalendarLocal(1_000_000_000_000);
+  assert.equal(a, b);
+});


### PR DESCRIPTION
## What

- **`.github/workflows/ci.yml`**: on `push` / `pull_request` to `main`, run `npm ci` and `npm test` (which runs `tsc` + unit tests) on **ubuntu-latest** and **macos-latest** with **Node 20 and 22** (`fail-fast: false`).
- **`test/scheduler.test.ts`**: assertion on `formatOnCalendarLocal` output shape (M1 `systemd` timer compatibility).
- **`package.json`**: `test:unit` runs both parser and scheduler test files; `test` still `build` + `test:unit`.

## Why

- **Closes #9** — CI on push/PR.
- **Contributes to #7** — extends unit tests beyond parsers (more coverage for config merge / next-run math can be a follow-up).

**#11** (governance) can be **closed** as done: `typescript` / `@types/node` are already on `main`.

After merge, confirm the workflow is green; if the matrix is too slow or costly, drop `macos-latest` or one Node line.

Closes #9