### PR TITLE
M1: Dockerfile, docker runbook, CI build (#8)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Dependencies and build output (rebuilt in image)
+node_modules
+dist
+
+# Local runtime & secrets
+var
+ai-limit-timer.config.json
+.claude
+.omx
+
+# VCS
+.git
+.github
+.gitignore
+
+# Docs not needed in build context
+docs
+
+# Not needed to compile
+LICENSE
+.editorconfig
+.prettierrc
+.eslintrc*
+eslint.config.*
+
+# Tests not copied into first stage? We need test/ in builder — do not ignore test/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,12 @@ jobs:
 
       - name: Test (build + unit tests)
         run: npm test
+
+  # Dockerfile smoke build (M1: no push to a registry)
+  docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Docker build
+        run: docker build -t ai-limit-timer:ci .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+# M1: in-repo image for running the tool on Linux/CI. See docs/docker.md for
+# host CLIs, volumes, and scheduling (container does not replace host systemd in
+# typical setups).
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+COPY test ./test
+# Compile only: runtime needs dist/; node_modules is not required to execute
+# (all imports are node:*). Tests are not shipped in the final stage.
+RUN npm run build && rm -rf dist/test
+
+FROM node:22-bookworm-slim
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build --chown=node:node /app/dist ./dist
+USER node
+ENTRYPOINT ["node", "dist/src/ai-limit-timer.js"]
+CMD ["status"]

--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ From here, the timer manages itself. It will wake up after each reset, send the 
 
 **Note:** A plain `npm install` in this project only installs Node dependencies. It does **not** register OS jobs — use `npm run timer:install` (after `build`) for that. The `npm` lifecycle name `install` is intentionally **not** used as a script name here, so dependency installs do not side-effect into `launchd` or `systemd`.
 
+## Docker (M1, in-repo only)
+
+- **Build an image:** `docker build -t ai-limit-timer:local .`
+- **How to run** (mounts, `codex` / `claude` paths, and scheduling vs host): see **[docs/docker.md](docs/docker.md)**.
+
+M1 only ships a `Dockerfile` and this doc; a **registry image** and tags are planned for the **M2** milestone.
+
 ## Configuration
 
 All settings in `ai-limit-timer.config.json`. Only `workspaceDir` is required — everything else has sensible defaults.
@@ -205,6 +212,8 @@ Set `"enabled": false` to skip either provider entirely:
 
 ```
 ai-limit-timer/
+├── Dockerfile                 # M1: optional container build (no registry in M1)
+├── .dockerignore
 ├── src/
 │   ├── ai-limit-timer.ts      # Main entrypoint: CLI, scheduling, orchestration
 │   ├── config.ts
@@ -215,6 +224,8 @@ ai-limit-timer/
 │       ├── launchd.ts
 │       ├── shared.ts
 │       └── systemd.ts
+├── docs/
+│   └── docker.md
 ├── dist/                      # Created by `npm run build` (not committed)
 ├── test/
 │   └── parsers.test.ts

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,80 @@
+# AI Limit Timer in Docker (M1)
+
+The repository ships a small **OCI** image for **running** the program on a Linux system (or a Linux engine such as Colima, Docker Desktop, or Podman). The image is **in-repo** only (M1); **no** registry is published in this milestone (see the M2 milestone for GHCR, etc.).
+
+## What the image is for
+
+- Run **`status`** (default command) or **`run`** in a one-shot or scripted way, with a mounted config and state directory.
+- **It does not install `codex` or `claude` for you.** Those CLIs are expected to exist in the same filesystem namespace as the process (e.g. bind-mounted from the host) or a path you set in the JSON config. Without them, only parser-adjacent logic that does not need those binaries will behave like on the host.
+
+**Scheduling (systemd / launchd):** Installing user timers is meant for a **host** with a logind / GUI session, not a minimal container without `systemd` user management and D-Bus. For a container workflow, use **the host** (cron, systemd on the host, Kubernetes CronJob) to `docker run ... run` on an interval, or use `run` manually.
+
+## Build
+
+From the repository root (requires Docker BuildKit — default in recent Docker):
+
+```bash
+docker build -t ai-limit-timer:local .
+```
+
+## Run: status
+
+Mount your **config** and **var** (state, logs) so the app can read/write. Use a **config path** that exists inside the container. Example layout:
+
+| Host | Container | Mode |
+|------|-------------|------|
+| `./ai-limit-timer.config.json` | `/data/ai-limit-timer.config.json` | read-only (config) |
+| `./var` | `/data/var` | read-write (state) |
+| `~/.codex/sessions` | `/data/.codex/sessions` | read-only (Codex logs) if you use Codex |
+
+Your config must point `codex.sessionRoot` and provider `workspaceDir` (and any paths) at locations **inside** the container that you mount, e.g. `"/data/.codex/sessions"`, `"/workspaces/codex"`.
+
+```bash
+docker run --rm \
+  -v "$PWD/ai-limit-timer.config.json:/data/ai-limit-timer.config.json:ro" \
+  -v "$PWD/var:/data/var" \
+  -e HOME=/data \
+  ai-limit-timer:local \
+  status --config /data/ai-limit-timer.config.json
+```
+
+`HOME=/data` makes `~/.codex` resolve under `/data` if you use `~` in the config.
+
+## Run: one cycle (`run`)
+
+```bash
+docker run --rm \
+  -v "$PWD/ai-limit-timer.config.json:/data/ai-limit-timer.config.json:ro" \
+  -v "$PWD/var:/data/var" \
+  -v "/abs/path/codex/bin:/opt/bin:ro" \
+  -e PATH="/opt/bin:/usr/local/bin:/usr/bin:/bin" \
+  -e HOME=/data \
+  ai-limit-timer:local \
+  run --config /data/ai-limit-timer.config.json
+```
+
+Point `codex.command` and `claude.command` in JSON at the mounted CLI paths, or add them to `PATH` as above. **Claude** often needs a trusted `workspaceDir` that exists in the mount namespace.
+
+## Avoid spaces in generated paths (Linux + systemd on host)
+
+If you use the **host** to install the systemd units created for Linux, the generated unit files are easiest when **paths contain no spaces**. Prefer short mount paths (e.g. `/data/...`).
+
+## Non-root
+
+The image runs as the **`node`** user (uid **1000** in the base image). Ensure mounted directories are readable/writable by that uid, e.g.:
+
+```bash
+chown -R 1000:1000 var
+```
+
+## Health check
+
+The image has no `HEALTHCHECK` (optional follow-up for M2+).
+
+## Compose (optional)
+
+You can create a `compose.yaml` that mirrors the `docker run` above (bind mounts, `environment`, `user: "1000:1000"` if you align uid). No compose file is committed in M1 to avoid prescriptive local paths; copy the examples here.
+
+---
+
+**M1 vs M2:** Pushing a tagged image to a registry (e.g. GHCR) and CI publish are **M2** work.


### PR DESCRIPTION
## What

- **`Dockerfile`**: two-stage build (`bookworm-slim`, Node 22); final image contains only `dist/` (app uses `node:` builtins — no `node_modules` in runtime) and runs as `node` user. Default `CMD` is `status`.
- **`.dockerignore`**: slimmer build context; source still includes `test/` for `tsc`.
- **`docs/docker.md`**: how to `docker build`, mount config/`var`/`\.codex`, wire `codex`/`claude`, and why in-container `systemd` is not the default story; host-based scheduling and M2 registry called out.
- **`README.md`**: short Docker section + file tree.
- **CI**: new `docker-image` job on `ubuntu-latest` — `docker build -t ai-limit-timer:ci .` (no push).

## Note

`docker build` was not run in this dev environment (no Docker CLI); the **new workflow job** is the first automated validation.

Closes #8

Made with [Cursor](https://cursor.com)