### PR TITLE
ci: use checkout@v5 and setup-node@v5 (Node 24 action runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
           cache: npm
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci
@@ -39,6 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Docker build
         run: docker build -t ai-limit-timer:ci .


### PR DESCRIPTION
## Problem

GitHub annotations warn that `actions/checkout@v4` and `actions/setup-node@v4` run on the deprecated **Node 20** JavaScript action runtime.

## Change

- `actions/checkout@v4` → `@v5` (build-test + **docker-image**)
- `actions/setup-node@v4` → `@v5` (build-test)
- `package-manager-cache: false` so setup-node v5’s automatic package-manager-based cache does not layer on top of the explicit `cache: npm` we already use (see [setup-node v5 `action.yml`](https://github.com/actions/setup-node/blob/v5/action.yml)).

## Notes

- checkout v5 requires [Actions Runner ≥ 2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) for `using: node24`; **GitHub-hosted** runners satisfy this. Self‑hosted runners must be updated.
- The **app** is still tested on Node **20** and **22** via the matrix; this PR only changes the **action** runtimes, not the Node version under test.

Made with [Cursor](https://cursor.com)