### PR TITLE
M1: Reliability (spawn/config), platform docs, CONTRIBUTING (#6 #7 #10 #12, #11)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+## Dev dependencies
+
+`typescript` and `@types/node` are the agreed toolchain to build the project (see `package.json`). No additional approval is required to rely on them for this repository.
+
+## Quick loop
+
+```bash
+npm install
+npm test
+```
+
+`npm test` compiles with `tsc` and runs `node --test` on the files under `test/`. Use `npm run typecheck` for a no-emit check only.
+
+## Branches and CI
+
+- Open PRs against `main`. CI runs `npm test` (Linux + macOS, Node 20/22) and a smoke `docker build` on Ubuntu.
+- Keep changes scoped; match existing style and run tests before pushing.
+
+## Security and process CLIs
+
+The app shells out to your configured `codex` and `claude` binaries (never via `shell: true`). If spawn fails with “not found on PATH or not executable”, install the tool or set an absolute `command` in the JSON config.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ If your Mac is off or asleep when a scheduled reset passes, the job runs automat
 - **Codex CLI** (`codex`) — [install guide](https://github.com/openai/codex)
 - **Claude Code** (`claude`) — [install guide](https://docs.anthropic.com/en/docs/claude-code)
 
+### Supported platforms (M1)
+
+| | In scope for M1 | Not targeted in M1 |
+|---|-----------------|------------------------|
+| **OS** | **macOS** and **Linux** (glibc-based distros with `systemd` for user timers) | **Windows** (native) |
+| **Environment** | Bare metal, VM, or container (see [docs/docker.md](docs/docker.md)) | **WSL2** and **graphical** installers as *supported* test targets (may work, not guaranteed) |
+| **UI** | CLI only | Web UI or desktop GUI |
+
+M2+ may expand Linux scheduler backends, a public container registry, and other delivery options; see the repo milestones.
+
+**Contributing:** [CONTRIBUTING.md](CONTRIBUTING.md) (dev loop, CI, and tooling).
+
 ## Setup
 
 ### 1. Clone and configure
@@ -135,7 +147,7 @@ From here, the timer manages itself. It will wake up after each reset, send the 
 | `npm run uninstall-launchd` | Same as `timer:uninstall` for `launchd` |
 | `npm run install-systemd` | Same as `timer:install` when `scheduler.type` is `systemd` (Linux) |
 | `npm run uninstall-systemd` | Same as `timer:uninstall` for `systemd` |
-| `npm test` | Build and run parser unit tests |
+| `npm test` | Build and run unit tests |
 
 **Note:** A plain `npm install` in this project only installs Node dependencies. It does **not** register OS jobs — use `npm run timer:install` (after `build`) for that. The `npm` lifecycle name `install` is intentionally **not** used as a script name here, so dependency installs do not side-effect into `launchd` or `systemd`.
 
@@ -145,6 +157,12 @@ From here, the timer manages itself. It will wake up after each reset, send the 
 - **How to run** (mounts, `codex` / `claude` paths, and scheduling vs host): see **[docs/docker.md](docs/docker.md)**.
 
 M1 only ships a `Dockerfile` and this doc; a **registry image** and tags are planned for the **M2** milestone.
+
+### Environment variables
+
+| Variable | Effect |
+|----------|--------|
+| `AI_LIMIT_TIMER_CONFIG` | Path to the JSON config file if you do **not** pass `--config`. Handy in Docker, systemd units, or CI. The CLI still wins: `--config` overrides this. |
 
 ## Configuration
 
@@ -226,6 +244,7 @@ ai-limit-timer/
 │       └── systemd.ts
 ├── docs/
 │   └── docker.md
+├── CONTRIBUTING.md
 ├── dist/                      # Created by `npm run build` (not committed)
 ├── test/
 │   └── parsers.test.ts

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -34,11 +34,12 @@ docker run --rm \
   -v "$PWD/ai-limit-timer.config.json:/data/ai-limit-timer.config.json:ro" \
   -v "$PWD/var:/data/var" \
   -e HOME=/data \
+  -e AI_LIMIT_TIMER_CONFIG=/data/ai-limit-timer.config.json \
   ai-limit-timer:local \
-  status --config /data/ai-limit-timer.config.json
+  status
 ```
 
-`HOME=/data` makes `~/.codex` resolve under `/data` if you use `~` in the config.
+Using `AI_LIMIT_TIMER_CONFIG` matches how you can run the app without a long `CMD` (same precedence as the CLI: you can still pass `status --config /path/...` if you prefer). `HOME=/data` makes `~/.codex` resolve under `/data` if you use `~` in the config.
 
 ## Run: one cycle (`run`)
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "uninstall-launchd": "node dist/src/ai-limit-timer.js uninstall-launchd",
     "install-systemd": "node dist/src/ai-limit-timer.js install-systemd",
     "uninstall-systemd": "node dist/src/ai-limit-timer.js uninstall-systemd",
-    "test:unit": "node --test dist/test/parsers.test.js dist/test/scheduler.test.js",
+    "test:unit": "node --test dist/test/parsers.test.js dist/test/scheduler.test.js dist/test/config-path.test.js",
     "test": "npm run build && npm run test:unit"
   },
   "devDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -235,8 +235,22 @@ function finalizeConfig(config: ReturnType<typeof defaultConfig> & { configPath?
 
 export { DEFAULT_CONFIG_FILE, DEFAULT_PROMPT, DEFAULT_LAUNCH_LABEL };
 
+/**
+ * Resolves the config file path. Precedence: CLI `--config`, then `AI_LIMIT_TIMER_CONFIG`, then `ai-limit-timer.config.json`.
+ */
+export function resolveConfigPathFromEnv(cliConfigPath: string | null) {
+  if (cliConfigPath != null && cliConfigPath !== "") {
+    return cliConfigPath;
+  }
+  const fromEnv = process.env.AI_LIMIT_TIMER_CONFIG?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  return DEFAULT_CONFIG_FILE;
+}
+
 export async function loadConfig(configPathArg: string | null) {
-  const configPath = absoluteFrom(process.cwd(), configPathArg ?? DEFAULT_CONFIG_FILE);
+  const configPath = absoluteFrom(process.cwd(), resolveConfigPathFromEnv(configPathArg));
   const base = defaultConfig(configPath);
   if (await pathExists(configPath)) {
     const raw = await fsp.readFile(configPath, "utf8");

--- a/src/run-child.ts
+++ b/src/run-child.ts
@@ -62,8 +62,16 @@ export function runCommand(command: string, args: string[], options: RunOptions 
       appendLimited("stderr", chunk);
     });
 
-    child.on("error", (error: Error) => {
+    child.on("error", (error: NodeJS.ErrnoException) => {
       clearTimeout(timer);
+      if (error.code === "ENOENT") {
+        reject(
+          new Error(
+            `Could not start "${command}": not found on PATH or not executable. Install the CLI or set an absolute path in config (e.g. codex.command). ${error.message}`,
+          ),
+        );
+        return;
+      }
       reject(error);
     });
 

--- a/test/config-path.test.ts
+++ b/test/config-path.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { loadConfig, resolveConfigPathFromEnv } from "../src/config.js";
+import { runCommand } from "../src/run-child.js";
+
+test("resolveConfigPathFromEnv: CLI wins over env and default", () => {
+  const prev = process.env.AI_LIMIT_TIMER_CONFIG;
+  process.env.AI_LIMIT_TIMER_CONFIG = "/env/config.json";
+  try {
+    assert.equal(resolveConfigPathFromEnv("/cli/config.json"), "/cli/config.json");
+  } finally {
+    if (prev === undefined) {
+      delete process.env.AI_LIMIT_TIMER_CONFIG;
+    } else {
+      process.env.AI_LIMIT_TIMER_CONFIG = prev;
+    }
+  }
+});
+
+test("resolveConfigPathFromEnv: env when CLI null", () => {
+  const prev = process.env.AI_LIMIT_TIMER_CONFIG;
+  process.env.AI_LIMIT_TIMER_CONFIG = "  /data/app.json  ";
+  try {
+    assert.equal(resolveConfigPathFromEnv(null), "/data/app.json");
+  } finally {
+    if (prev === undefined) {
+      delete process.env.AI_LIMIT_TIMER_CONFIG;
+    } else {
+      process.env.AI_LIMIT_TIMER_CONFIG = prev;
+    }
+  }
+});
+
+test("runCommand: ENOENT produces an actionable error", async () => {
+  await assert.rejects(
+    async () => {
+      await runCommand("ailimit-timer-missing-exe-42", [], { timeoutMs: 2000 });
+    },
+    (err) => {
+      const e = err as Error;
+      return /not found on PATH|not executable/.test(e.message) && e.message.includes("ailimit-timer-missing-exe-42");
+    },
+  );
+});
+
+test("loadConfig: reads AI_LIMIT_TIMER_CONFIG when set (absolute path)", async () => {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "ailimit-"));
+  const cfg = path.join(dir, "c.json");
+  await fsp.writeFile(cfg, "{}", "utf8");
+  const prev = process.env.AI_LIMIT_TIMER_CONFIG;
+  process.env.AI_LIMIT_TIMER_CONFIG = cfg;
+  try {
+    const c = await loadConfig(null);
+    assert.equal(path.normalize(c.configPath), path.normalize(path.resolve(cfg)));
+  } finally {
+    if (prev === undefined) {
+      delete process.env.AI_LIMIT_TIMER_CONFIG;
+    } else {
+      process.env.AI_LIMIT_TIMER_CONFIG = prev;
+    }
+    await fsp.rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

### Reliability (#6)
- **Spawn errors:** `ENOENT` from `child_process.spawn` is surfaced as a clear message (install CLI or set absolute `codex.command` / `claude.command`).
- **Docker / automation:** `AI_LIMIT_TIMER_CONFIG` selects the JSON file when `--config` is **not** passed (precedence: **`--config` > env > `ai-limit-timer.config.json`**). Documented in README and in `docs/docker.md` (status example uses env so default `CMD` works when config is mounted).

### Tests (#7)
- `test/config-path.test.ts` — `resolveConfigPathFromEnv`, `loadConfig` with env, and spawn ENOENT behavior.

### Documentation (#10, #12)
- README **Supported platforms (M1)** table (in/out of scope: Windows, WSL, GUI, CLI-only, Docker as environment).
- **Environment variables** table for `AI_LIMIT_TIMER_CONFIG`.
- **CONTRIBUTING.md** — dev loop, CI expectations, TypeScript tooling note (**closes governance #11** in practice).

## Closes

Closes #6, closes #7, closes #10, closes #12, closes #11

Made with [Cursor](https://cursor.com)